### PR TITLE
test: remove legacy provider cases from config and pricing tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -94,15 +94,6 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Valid OpenAI config (API key can be empty, validation only checks provider existence)",
-			config: &Config{
-				Provider:     "openai",
-				Model:        "gpt-4o",
-				OpenAIAPIKey: "",
-			},
-			wantErr: false, // We don't validate API key presence here
-		},
-		{
 			name: "Invalid - missing Ollama URL",
 			config: &Config{
 				Provider:  "ollama",

--- a/internal/provider/pricing_test.go
+++ b/internal/provider/pricing_test.go
@@ -10,10 +10,6 @@ func TestGetPricing(t *testing.T) {
 		model    string
 		wantCost bool // whether cost should be > 0
 	}{
-		{"openai", "gpt-4o", true},
-		{"openai", "gpt-3.5-turbo", true},
-		{"anthropic", "claude-4-5-sonnet", true},
-		{"gemini", "gemini-flash-2.5", true},
 		{"ollama", "llama2", false},
 		{"unknown", "unknown", false},
 	}


### PR DESCRIPTION
- Delete OpenAI validation test case from config_test.go
- Remove OpenAI, Anthropic, and Gemini entries from pricing_test.go
- Ensure test suite aligns with the streamlined provider support (Ollama and OpenRouter)