### PR TITLE
fix(provider): add HTTP client timeout and scanner buffer limit

### DIFF
--- a/internal/provider/base.go
+++ b/internal/provider/base.go
@@ -6,6 +6,14 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
+)
+
+const DefaultHTTPTimeout = 30 * time.Second
+
+const (
+	scannerInitialBufSize = 64 * 1024  // 64KB initial
+	scannerMaxBufSize     = 1024 * 1024 // 1MB max line
 )
 
 type BaseProvider struct {
@@ -45,6 +53,7 @@ func GenericStream(
 		defer close(toolChan)
 
 		scanner := bufio.NewScanner(body)
+		scanner.Buffer(make([]byte, scannerInitialBufSize), scannerMaxBufSize)
 		var accumulatedTools []ToolCall
 		var lastUsage Usage
 

--- a/internal/provider/http_test.go
+++ b/internal/provider/http_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultHTTPTimeout(t *testing.T) {
+	if DefaultHTTPTimeout != 30*time.Second {
+		t.Errorf("DefaultHTTPTimeout = %v, want 30s", DefaultHTTPTimeout)
+	}
+}
+
+func TestOllamaProvider_HTTPTimeout(t *testing.T) {
+	p := NewOllamaProvider("http://localhost:11434", "test-model")
+	if p.httpClient.Timeout != DefaultHTTPTimeout {
+		t.Errorf("Ollama HTTP timeout = %v, want %v", p.httpClient.Timeout, DefaultHTTPTimeout)
+	}
+}
+
+func TestOpenRouterProvider_HTTPTimeout(t *testing.T) {
+	p := NewOpenRouterProvider("test-api-key", "test-model")
+	if p.httpClient.Timeout != DefaultHTTPTimeout {
+		t.Errorf("OpenRouter HTTP timeout = %v, want %v", p.httpClient.Timeout, DefaultHTTPTimeout)
+	}
+}
+
+func TestProvider_HTTPClientShared(t *testing.T) {
+	p := NewOllamaProvider("http://localhost:11434", "test-model")
+	if p.httpClient == nil {
+		t.Fatal("HTTP client is nil")
+	}
+	if p.httpClient.Timeout <= 0 {
+		t.Error("HTTP timeout should be positive")
+	}
+}
+
+func TestDefaultHTTPTimeout_NotZero(t *testing.T) {
+	if DefaultHTTPTimeout == 0 {
+		t.Error("DefaultHTTPTimeout should not be zero")
+	}
+}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -26,7 +26,9 @@ func NewOllamaProvider(url, model string) *OllamaProvider {
 		url:   url,
 		model: model,
 		BaseProvider: BaseProvider{
-			httpClient: &http.Client{},
+			httpClient: &http.Client{
+				Timeout: DefaultHTTPTimeout,
+			},
 		},
 	}
 }

--- a/internal/provider/openrouter.go
+++ b/internal/provider/openrouter.go
@@ -24,7 +24,9 @@ func NewOpenRouterProvider(apiKey, model string) *OpenRouterProvider {
 		model:   model,
 		baseURL: "https://openrouter.ai/api/v1",
 		BaseProvider: BaseProvider{
-			httpClient: &http.Client{},
+			httpClient: &http.Client{
+				Timeout: DefaultHTTPTimeout,
+			},
 		},
 	}
 }


### PR DESCRIPTION
- Add DefaultHTTPTimeout constant (30s) to base.go
- Set http.Client.Timeout in both NewOllamaProvider and NewOpenRouterProvider
- Add scanner buffer size limits in GenericStream (64KB init, 1MB max)
- Add unit tests verifying timeout is set correctly