### PR TITLE
refactor: optimize string formatting by removing fmt.Sprintf

### DIFF
--- a/internal/attachment/handler.go
+++ b/internal/attachment/handler.go
@@ -15,11 +15,11 @@ const (
 )
 
 var (
-	ErrFileNotFound    = errors.New("file not found")
-	ErrNotRegularFile  = errors.New("not a regular file")
-	ErrFileTooLarge    = errors.New("file exceeds maximum size limit")
-	ErrSymlinkLoop     = errors.New("symlink loop detected")
-	ErrSystemFile      = errors.New("system file access denied")
+	ErrFileNotFound   = errors.New("file not found")
+	ErrNotRegularFile = errors.New("not a regular file")
+	ErrFileTooLarge   = errors.New("file exceeds maximum size limit")
+	ErrSymlinkLoop    = errors.New("symlink loop detected")
+	ErrSystemFile     = errors.New("system file access denied")
 )
 
 var blockedUnixPrefixes = []string{
@@ -43,7 +43,7 @@ var blockedUnixPrefixes = []string{
 
 var (
 	windowsBlockedPrefixes []string
-	windowsBlockedOnce    bool
+	windowsBlockedOnce     bool
 )
 
 var blockedHomeDirs = []string{
@@ -179,42 +179,42 @@ func NewHandler() *Handler {
 	return &Handler{
 		maxFileSize: DefaultMaxFileSize,
 		allowedExts: map[string]bool{
-			".txt":  true,
-			".log":  true,
-			".json": true,
-			".yaml": true,
-			".yml":  true,
-			".md":   true,
-			".go":   true,
-			".mod":  true,
-			".sum":  true,
-			".py":   true,
-			".js":   true,
-			".ts":   true,
-			".jsx":  true,
-			".tsx":  true,
-			".java": true,
-			".c":    true,
-			".h":    true,
-			".cpp":  true,
-			".hpp":  true,
-			".rs":   true,
-			".rb":   true,
-			".php":  true,
-			".sh":   true,
-			".bash": true,
-			".zsh":  true,
-			".sql":  true,
-			".xml":  true,
-			".html": true,
-			".css":  true,
-			".scss": true,
-			".toml": true,
-			".ini":  true,
-			".cfg":  true,
-			".conf": true,
-			".env":  true,
-			".gitignore": true,
+			".txt":          true,
+			".log":          true,
+			".json":         true,
+			".yaml":         true,
+			".yml":          true,
+			".md":           true,
+			".go":           true,
+			".mod":          true,
+			".sum":          true,
+			".py":           true,
+			".js":           true,
+			".ts":           true,
+			".jsx":          true,
+			".tsx":          true,
+			".java":         true,
+			".c":            true,
+			".h":            true,
+			".cpp":          true,
+			".hpp":          true,
+			".rs":           true,
+			".rb":           true,
+			".php":          true,
+			".sh":           true,
+			".bash":         true,
+			".zsh":          true,
+			".sql":          true,
+			".xml":          true,
+			".html":         true,
+			".css":          true,
+			".scss":         true,
+			".toml":         true,
+			".ini":          true,
+			".cfg":          true,
+			".conf":         true,
+			".env":          true,
+			".gitignore":    true,
 			".dockerignore": true,
 		},
 	}
@@ -327,7 +327,7 @@ func (h *Handler) FormatComponents(components []ContextComponent) string {
 	sb.WriteString("================\n\n")
 
 	for _, c := range components {
-		sb.WriteString(fmt.Sprintf("=== %s ===\n", filepath.Base(c.Name)))
+		sb.WriteString("=== " + filepath.Base(c.Name) + " ===\n")
 		sb.WriteString(c.Content)
 		sb.WriteString("\n")
 	}

--- a/internal/context/workspace.go
+++ b/internal/context/workspace.go
@@ -151,7 +151,7 @@ func (s *WorkspaceScanner) CollectContext(exec executor.Executor, workspaceDir s
 		result.WriteString("Text Files:\n")
 		result.WriteString("-------------\n")
 		for _, f := range textFiles {
-			result.WriteString(fmt.Sprintf("\n=== %s ===\n", f.Path))
+			result.WriteString("\n=== " + f.Path + " ===\n")
 			result.WriteString(f.Content)
 			result.WriteString("\n")
 		}
@@ -162,7 +162,7 @@ func (s *WorkspaceScanner) CollectContext(exec executor.Executor, workspaceDir s
 	if len(binaryFiles) > 0 {
 		result.WriteString("Binary Files (content not shown):\n")
 		for _, f := range binaryFiles {
-			result.WriteString(fmt.Sprintf("  - %s\n", f))
+			result.WriteString("  - " + f + "\n")
 		}
 		result.WriteString("\n")
 	}
@@ -171,7 +171,7 @@ func (s *WorkspaceScanner) CollectContext(exec executor.Executor, workspaceDir s
 	if len(largeFiles) > 0 {
 		result.WriteString("Large Files (exceeded size limit, content not shown):\n")
 		for _, f := range largeFiles {
-			result.WriteString(fmt.Sprintf("  - %s\n", f))
+			result.WriteString("  - " + f + "\n")
 		}
 		result.WriteString("\n")
 	}

--- a/internal/export/markdown.go
+++ b/internal/export/markdown.go
@@ -1,7 +1,7 @@
 package export
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -11,12 +11,12 @@ func (e *Exporter) exportMarkdown(session *Session) string {
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString(fmt.Sprintf("# %s\n\n", session.Title))
-	sb.WriteString(fmt.Sprintf("**Session ID:** %d  \n", session.ID))
-	sb.WriteString(fmt.Sprintf("**Provider:** %s  \n", session.Provider))
-	sb.WriteString(fmt.Sprintf("**Model:** %s  \n", session.Model))
-	sb.WriteString(fmt.Sprintf("**Created:** %s  \n", session.CreatedAt.Format("2006-01-02 15:04:05")))
-	sb.WriteString(fmt.Sprintf("**Updated:** %s  \n\n", session.UpdatedAt.Format("2006-01-02 15:04:05")))
+	sb.WriteString("# " + session.Title + "\n\n")
+	sb.WriteString("**Session ID:** " + strconv.FormatUint(uint64(session.ID), 10) + "  \n")
+	sb.WriteString("**Provider:** " + session.Provider + "  \n")
+	sb.WriteString("**Model:** " + session.Model + "  \n")
+	sb.WriteString("**Created:** " + session.CreatedAt.Format("2006-01-02 15:04:05") + " \n")
+	sb.WriteString("**Updated:** " + session.UpdatedAt.Format("2006-01-02 15:04:05") + "\n\n")
 	sb.WriteString("---\n\n")
 
 	// Messages
@@ -26,7 +26,7 @@ func (e *Exporter) exportMarkdown(session *Session) string {
 		if msg.Role == "assistant" {
 			role = "**Assistant:**"
 		}
-		sb.WriteString(fmt.Sprintf("%s\n\n", role))
+		sb.WriteString(role + "\n\n")
 
 		// Message content with proper markdown escaping
 		content := msg.Content
@@ -38,12 +38,12 @@ func (e *Exporter) exportMarkdown(session *Session) string {
 		sb.WriteString("\n")
 
 		// Timestamp
-		sb.WriteString(fmt.Sprintf("*%s*\n\n", msg.CreatedAt.Format("15:04:05")))
+		sb.WriteString("*" + msg.CreatedAt.Format("15:04:05") + "*\n\n")
 		sb.WriteString("---\n\n")
 	}
 
 	// Footer
-	sb.WriteString(fmt.Sprintf("\n*Exported on %s*\n", time.Now().Format("2006-01-02 15:04:05")))
+	sb.WriteString("\n*Exported on *" + time.Now().Format("2006-01-02 15:04:05") + "*\n")
 
 	return sb.String()
 }

--- a/internal/provider/base.go
+++ b/internal/provider/base.go
@@ -57,6 +57,7 @@ func GenericStream(
 		var accumulatedTools []ToolCall
 		var lastUsage Usage
 
+	loop:
 		for scanner.Scan() {
 			select {
 			case <-ctx.Done():
@@ -74,8 +75,6 @@ func GenericStream(
 				}
 
 				if len(tools) > 0 {
-					// Stitch tool fragments (Ollama usually sends them whole,
-					// but this logic supports incremental fragments too)
 					for _, tc := range tools {
 						if tc.Index >= len(accumulatedTools) {
 							accumulatedTools = append(accumulatedTools, tc)
@@ -90,7 +89,7 @@ func GenericStream(
 				}
 
 				if done {
-					break
+					break loop
 				}
 			}
 		}

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
@@ -43,11 +44,6 @@ type ChatModel struct {
 	lastUsage      provider.Usage
 }
 
-const (
-	headerHeight = 1
-	footerHeight = 3
-)
-
 var (
 	headerStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("205")).
@@ -63,13 +59,6 @@ var (
 
 	inputFocusedStyle = inputBorderStyle.
 				BorderForeground(lipgloss.Color("205"))
-
-	userMsgStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("86")).
-			Bold(true)
-
-	aiMsgStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("212"))
 
 	sidebarBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
@@ -110,10 +99,11 @@ func NewChatModel(
 	// Populate initial messages for display
 	displayMessages := make([]string, 0, len(initialMessages))
 	for _, msg := range initialMessages {
-		if msg.Role == "user" {
-			displayMessages = append(displayMessages, fmt.Sprintf("You: %s", msg.Content))
-		} else if msg.Role == "assistant" {
-			displayMessages = append(displayMessages, fmt.Sprintf("AI: %s", msg.Content))
+		switch msg.Role {
+		case "user":
+			displayMessages = append(displayMessages, "You: "+msg.Content)
+		case "assistant":
+			displayMessages = append(displayMessages, "AI: "+msg.Content)
 		}
 	}
 
@@ -327,17 +317,19 @@ func (m *ChatModel) renderSidebarContent() string {
 	sb.WriteString("\n\n")
 
 	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Model:"))
-	sb.WriteString(fmt.Sprintf("\n%s\n\n", m.cfg.Model))
+	sb.WriteString("\n" + m.cfg.Model + "\n\n")
 
 	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Tokens:"))
-	sb.WriteString(fmt.Sprintf("\nPrompt: %d", m.lastUsage.PromptTokens))
-	sb.WriteString(fmt.Sprintf("\nCompl:  %d", m.lastUsage.CompletionTokens))
-	sb.WriteString(fmt.Sprintf("\nTotal:  %d\n\n", m.lastUsage.TotalTokens))
+	sb.WriteString("\nPrompt: " + strconv.Itoa(m.lastUsage.PromptTokens))
+	sb.WriteString("\nCompl: " + strconv.Itoa(m.lastUsage.CompletionTokens))
+	sb.WriteString("\nTotal: \n\n" + strconv.Itoa(m.lastUsage.TotalTokens))
 
 	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Cost:"))
-	sb.WriteString(fmt.Sprintf("\n$%.6f", m.lastUsage.EstimatedCost))
 
-	sb.WriteString(fmt.Sprint("\n\n")) // add whitespace
+	costStr := strconv.FormatFloat(m.lastUsage.EstimatedCost, 'f', 6, 64)
+	sb.WriteString("\n$" + costStr)
+
+	sb.WriteString("\n\n") // add whitespace
 
 	// Environment Workspace Stats (Directory & Git Branch)
 	sb.WriteString(lipgloss.NewStyle().Bold(true).Underline(true).Render("Workspace"))
@@ -354,7 +346,7 @@ func (m *ChatModel) renderSidebarContent() string {
 		}
 	}
 	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Directory:"))
-	sb.WriteString(fmt.Sprintf("\n%s\n\n", dir))
+	sb.WriteString("\n" + dir + "\n\n")
 
 	// Get Git Branch Name
 	branch := "Not a repository"
@@ -363,7 +355,7 @@ func (m *ChatModel) renderSidebarContent() string {
 		branch = strings.TrimSpace(string(output))
 	}
 	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Branch:"))
-	sb.WriteString(fmt.Sprintf("\n%s\n", branch))
+	sb.WriteString("\n" + branch + "\n")
 
 	return sb.String()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,7 +3,6 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"strings"
 )
 
 var (
@@ -22,16 +21,12 @@ var (
 
 // Info returns the complete version information
 func Info() string {
-	var sb strings.Builder
-
-	sb.WriteString(fmt.Sprintf("Version: %s\n", Version))
-	sb.WriteString(fmt.Sprintf("Commit: %s\n", Commit))
-	sb.WriteString(fmt.Sprintf("Built: %s\n", Date))
-	sb.WriteString(fmt.Sprintf("Built by: %s\n", BuiltBy))
-	sb.WriteString(fmt.Sprintf("Go version: %s\n", runtime.Version()))
-	sb.WriteString(fmt.Sprintf("OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH))
-
-	return sb.String()
+	return "Version: " + Version + "\n" +
+		"Commit: " + Commit + "\n" +
+		"Built: " + Date + "\n" +
+		"Built by: " + BuiltBy + "\n" +
+		"Go version: " + runtime.Version() + "\n" +
+		"OS/Arch: " + runtime.GOOS + "/" + runtime.GOARCH + "\n"
 }
 
 // Short returns a short version string


### PR DESCRIPTION
Replaces various instances of `fmt.Sprintf` and `fmt.Sprint` across the codebase with direct string concatenation (`+`) and explicit `strconv` conversions. This reduces the runtime reflection and allocation overhead inherent to the `fmt` package's parsing logic.

Additional cleanups included:
- Fixed a broken `break` statement in `internal/provider/base.go` by adding a loop label (`loop:`) to properly break out of the selective for-loop scanner.
- Cleaned up unused constants, variables, and imports (`strings` in `version.go`).
- Unified struct literal alignment for code readability.