### PR TITLE
feat(executor): harden file blocklist policy and fix concurrency data…

### DIFF
--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -10,10 +10,24 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 )
 
-// DefaultBlocklist contains dangerous system commands blocked by default.
-var DefaultBlocklist = []string{
+// defaultFileBlocklist contains sensitive file path patterns blocked by default.
+// Patterns use filepath.Match syntax and are matched against paths relative to the workspace root.
+var defaultFileBlocklist = []string{
+	".env*",
+	"*.pem",
+	"*.key",
+	"id_*",
+	".ssh/*",
+	".gnupg/*",
+	".netrc",
+	".git-credentials",
+}
+
+// defaultBlocklist contains dangerous system commands blocked by default.
+var defaultBlocklist = []string{
 	"dd",
 	"mkfs",
 	"fdisk",
@@ -37,9 +51,17 @@ type CommandPolicy struct {
 	Blocklist []string
 }
 
+// FilePolicy defines block rules for file operations.
+// Blocklist entries are glob patterns matched against paths relative to the workspace root.
+type FilePolicy struct {
+	Blocklist []string
+}
+
 type LocalExecutor struct {
-	rootDir string
-	policy  CommandPolicy
+	mu         sync.RWMutex
+	rootDir    string
+	policy     CommandPolicy
+	filePolicy FilePolicy
 }
 
 func NewLocal(rootDir string) (*LocalExecutor, error) {
@@ -53,7 +75,10 @@ func NewLocal(rootDir string) (*LocalExecutor, error) {
 	return &LocalExecutor{
 		rootDir: abs,
 		policy: CommandPolicy{
-			Blocklist: slices.Clone(DefaultBlocklist),
+			Blocklist: slices.Clone(defaultBlocklist),
+		},
+		filePolicy: FilePolicy{
+			Blocklist: slices.Clone(defaultFileBlocklist),
 		},
 	}, nil
 }
@@ -107,9 +132,45 @@ func isWithinRoot(rootDir, resolvedPath string) bool {
 	return strings.HasPrefix(resolvedPath, prefix) || resolvedPath == rootResolved
 }
 
+// checkFilePolicy enforces the file blocklist for a given resolved absolute path.
+func (l *LocalExecutor) checkFilePolicy(absPath string) error {
+	rel, err := filepath.Rel(l.rootDir, absPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute relative path: %w", err)
+	}
+	clean := filepath.ToSlash(rel)
+
+	l.mu.RLock()
+	blocklist := l.filePolicy.Blocklist
+	l.mu.RUnlock()
+
+	for _, pattern := range blocklist {
+		if matched, _ := filepath.Match(pattern, clean); matched {
+			return fmt.Errorf("file path %q matches blocked pattern %q", clean, pattern)
+		}
+
+		// Check each path suffix to catch directory-bound patterns
+		// at any nesting level, e.g. ".ssh/*" must match:
+		//   ".ssh/authorized_keys"                 (suffix starts at .ssh)
+		//   "config/infra/.ssh/authorized_keys"    (suffix starts at .ssh)
+		// while "*.pem" must still match "secret.pem" at any depth.
+		parts := strings.Split(clean, "/")
+		for i := 1; i < len(parts); i++ {
+			suffix := strings.Join(parts[i:], "/")
+			if matched, _ := filepath.Match(pattern, suffix); matched {
+				return fmt.Errorf("file path %q matches blocked pattern %q", clean, pattern)
+			}
+		}
+	}
+	return nil
+}
+
 func (l *LocalExecutor) WriteFile(path string, data []byte) error {
 	full, err := l.resolvePath(path)
 	if err != nil {
+		return err
+	}
+	if err := l.checkFilePolicy(full); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
@@ -123,12 +184,18 @@ func (l *LocalExecutor) ReadFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := l.checkFilePolicy(full); err != nil {
+		return nil, err
+	}
 	return os.ReadFile(full)
 }
 
 func (l *LocalExecutor) DeleteFile(path string) error {
 	full, err := l.resolvePath(path)
 	if err != nil {
+		return err
+	}
+	if err := l.checkFilePolicy(full); err != nil {
 		return err
 	}
 	return os.Remove(full)
@@ -178,12 +245,17 @@ func (l *LocalExecutor) RunCommand(ctx context.Context, command []string) (strin
 
 // checkCommandPolicy enforces the allowlist/blocklist for a command binary name.
 func (l *LocalExecutor) checkCommandPolicy(bin string) error {
-	if len(l.policy.Allowlist) > 0 {
-		if !slices.Contains(l.policy.Allowlist, bin) {
+	l.mu.RLock()
+	allowlist := l.policy.Allowlist
+	blocklist := l.policy.Blocklist
+	l.mu.RUnlock()
+
+	if len(allowlist) > 0 {
+		if !slices.Contains(allowlist, bin) {
 			return fmt.Errorf("command %q is not in the allowlist", bin)
 		}
 	}
-	if slices.Contains(l.policy.Blocklist, bin) {
+	if slices.Contains(blocklist, bin) {
 		return fmt.Errorf("command %q is blocked", bin)
 	}
 	return nil
@@ -192,11 +264,25 @@ func (l *LocalExecutor) checkCommandPolicy(bin string) error {
 // SetPolicy replaces the current command policy.
 // Passing nil fields preserves existing values.
 func (l *LocalExecutor) SetPolicy(p CommandPolicy) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	if p.Allowlist != nil {
 		l.policy.Allowlist = slices.Clone(p.Allowlist)
 	}
 	if p.Blocklist != nil {
 		l.policy.Blocklist = slices.Clone(p.Blocklist)
+	}
+}
+
+// SetFilePolicy replaces the current file policy.
+// Passing a nil Blocklist preserves the existing value.
+func (l *LocalExecutor) SetFilePolicy(p FilePolicy) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if p.Blocklist != nil {
+		l.filePolicy.Blocklist = slices.Clone(p.Blocklist)
 	}
 }
 

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -349,7 +349,7 @@ func TestIsWithinRoot(t *testing.T) {
 	})
 }
 
-func TestDefaultBlocklist_BlocksDangerousCommands(t *testing.T) {
+func TestDefaultBlocklistBlocksDangerousCommands(t *testing.T) {
 	tests := []struct {
 		cmd string
 	}{
@@ -362,7 +362,7 @@ func TestDefaultBlocklist_BlocksDangerousCommands(t *testing.T) {
 		t.Run(tt.cmd, func(t *testing.T) {
 			exec := &LocalExecutor{
 				rootDir: t.TempDir(),
-				policy:  CommandPolicy{Blocklist: slices.Clone(DefaultBlocklist)},
+				policy:  CommandPolicy{Blocklist: slices.Clone(defaultBlocklist)},
 			}
 			_, err := exec.RunCommand(context.Background(), []string{tt.cmd})
 			if err == nil {
@@ -492,6 +492,241 @@ func TestSetPolicy(t *testing.T) {
 	}
 	if !strings.Contains(out, "ok") {
 		t.Errorf("expected output containing 'ok', got %q", out)
+	}
+}
+
+func TestNewLocalInitializesFileBlocklist(t *testing.T) {
+	exec, err := NewLocal(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+	if len(exec.filePolicy.Blocklist) == 0 {
+		t.Fatal("expected file blocklist to be initialized")
+	}
+}
+
+func TestCheckFilePolicy(t *testing.T) {
+	tmp := t.TempDir()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "blocked .env file", path: ".env", wantErr: true},
+		{name: "blocked .env.prod", path: ".env.production", wantErr: true},
+		{name: "blocked .env.local", path: ".env.local", wantErr: true},
+		{name: "blocked pem file", path: "cert.pem", wantErr: true},
+		{name: "blocked key file", path: "private.key", wantErr: true},
+		{name: "blocked id_rsa", path: "id_rsa", wantErr: true},
+		{name: "blocked id_ed25519", path: "id_ed25519", wantErr: true},
+		{name: "blocked id_ecdsa", path: "id_ecdsa", wantErr: true},
+		{name: "blocked .ssh file", path: ".ssh/authorized_keys", wantErr: true},
+		{name: "blocked .netrc", path: ".netrc", wantErr: true},
+		{name: "blocked .git-credentials", path: ".git-credentials", wantErr: true},
+		{name: "blocked key in subdir", path: "config/keys/secret.pem", wantErr: true},
+		{name: "blocked .env in subdir", path: "project/.env", wantErr: true},
+		{name: "blocked .ssh nested deep", path: "config/infra/.ssh/authorized_keys", wantErr: true},
+		{name: "blocked .gnupg nested", path: "users/alice/.gnupg/pubring.kbx", wantErr: true},
+		{name: "blocked id_rsa nested", path: "backup/ssh/id_rsa.old", wantErr: true},
+		{name: "allowed regular file", path: "main.go", wantErr: false},
+		{name: "allowed .txt", path: "notes.txt", wantErr: false},
+		{name: "allowed nested file", path: "src/main.go", wantErr: false},
+	}
+
+	exec := &LocalExecutor{
+		rootDir: tmp,
+		filePolicy: FilePolicy{
+			Blocklist: slices.Clone(defaultFileBlocklist),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			absPath := filepath.Join(tmp, tt.path)
+			err := exec.checkFilePolicy(absPath)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for path %q", tt.path)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for path %q: %v", tt.path, err)
+			}
+		})
+	}
+}
+
+func TestWriteFile_BlockedPaths(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockedPaths := []string{
+		".env",
+		".env.production",
+		"config/keys/cert.pem",
+		".ssh/id_rsa.pub",
+		"config/infra/.ssh/authorized_keys",
+		"id_ed25519",
+		".netrc",
+		".git-credentials",
+	}
+
+	for _, p := range blockedPaths {
+		t.Run(p, func(t *testing.T) {
+			err := exec.WriteFile(p, []byte("content"))
+			if err == nil {
+				t.Fatal("expected error for blocked path")
+			}
+			if !strings.Contains(err.Error(), "matches blocked pattern") {
+				t.Errorf("expected 'matches blocked pattern' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestWriteFile_AllowedPaths(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allowedPaths := []string{
+		"main.go",
+		"src/app.go",
+		"README.md",
+		"config/settings.json",
+		"scripts/build.sh",
+	}
+
+	for _, p := range allowedPaths {
+		t.Run(p, func(t *testing.T) {
+			err := exec.WriteFile(p, []byte("content"))
+			if err != nil {
+				t.Fatalf("unexpected error for path %q: %v", p, err)
+			}
+		})
+	}
+}
+
+func TestReadFile_BlockedPath(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = exec.ReadFile(".env")
+	if err == nil {
+		t.Fatal("expected error for blocked path")
+	}
+	if !strings.Contains(err.Error(), "matches blocked pattern") {
+		t.Errorf("expected 'matches blocked pattern' error, got: %v", err)
+	}
+}
+
+func TestDeleteFile_BlockedPath(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = exec.DeleteFile(".env")
+	if err == nil {
+		t.Fatal("expected error for blocked path")
+	}
+	if !strings.Contains(err.Error(), "matches blocked pattern") {
+		t.Errorf("expected 'matches blocked pattern' error, got: %v", err)
+	}
+}
+
+func TestSetFilePolicy(t *testing.T) {
+	tmp := t.TempDir()
+	exec := &LocalExecutor{
+		rootDir: tmp,
+		filePolicy: FilePolicy{
+			Blocklist: []string{"*.env"},
+		},
+	}
+
+	// Replace blocklist entirely
+	exec.SetFilePolicy(FilePolicy{
+		Blocklist: []string{"*.pem"},
+	})
+
+	if err := exec.checkFilePolicy(filepath.Join(tmp, "secret.pem")); err == nil {
+		t.Fatal("expected .pem files to be blocked after policy update")
+	}
+	// Old blocklist is replaced, so .env should no longer be blocked
+	if err := exec.checkFilePolicy(filepath.Join(tmp, ".env")); err != nil {
+		t.Fatal("expected .env to not be blocked after blocklist replacement")
+	}
+}
+
+func TestWriteFile_TraversalBypassBlocked(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Traversal is caught by resolvePath before checkFilePolicy even runs
+	err = exec.WriteFile("subdir/../../.env", []byte("hacked"))
+	if err == nil {
+		t.Fatal("expected error for traversal path")
+	}
+	if !strings.Contains(err.Error(), "escapes") {
+		t.Errorf("expected sandbox escape error, got: %v", err)
+	}
+}
+
+func TestWriteFile_SymlinkToBlockedFile(t *testing.T) {
+	tmp := t.TempDir()
+	exec, err := NewLocal(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a .env file and a symlink pointing to it
+	if err := os.WriteFile(filepath.Join(tmp, ".env"), []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "config"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../.env", filepath.Join(tmp, "config/link.env")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Writing through the symlink must be blocked:
+	// resolvePath resolves the symlink -> full path to .env
+	// checkFilePolicy then matches the resolved path against blocklist
+	err = exec.WriteFile("config/link.env", []byte("hacked"))
+	if err == nil {
+		t.Fatal("expected error for writing to .env through symlink")
+	}
+	if !strings.Contains(err.Error(), "matches blocked pattern") {
+		t.Errorf("expected 'matches blocked pattern' error, got: %v", err)
+	}
+}
+
+func TestSetFilePolicy_NilPreservesBlocklist(t *testing.T) {
+	tmp := t.TempDir()
+	exec := &LocalExecutor{
+		rootDir: tmp,
+		filePolicy: FilePolicy{
+			Blocklist: []string{"*.env"},
+		},
+	}
+
+	// Nil blocklist should preserve existing
+	exec.SetFilePolicy(FilePolicy{})
+
+	if err := exec.checkFilePolicy(filepath.Join(tmp, ".env")); err == nil {
+		t.Fatal("expected .env to remain blocked after nil update")
 	}
 }
 

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -42,6 +42,9 @@ type ChatModel struct {
 	titleGenerated bool
 	ready          bool
 	lastUsage      provider.Usage
+
+	toolCallDepth    int
+	maxToolCallDepth int
 }
 
 var (
@@ -66,7 +69,8 @@ var (
 )
 
 const (
-	sidebarWidth = 30
+	sidebarWidth            = 30
+	defaultMaxToolCallDepth = 25
 )
 
 type usageUpdateMsg provider.Usage
@@ -108,24 +112,25 @@ func NewChatModel(
 	}
 
 	return &ChatModel{
-		input:          input,
-		messages:       displayMessages,
-		sessionID:      sessionID,
-		cfg:            cfg,
-		prov:           prov,
-		dbManager:      dbManager,
-		exec:           exec,
-		ctx:            ctx,
-		cancel:         cancel,
-		waiting:        false,
-		prog:           nil,
-		fullResponse:   strings.Builder{},
-		messageHistory: history,
-		terminalWidth:  0,
-		terminalHeight: 0,
-		viewport:       viewport.New(0, 0),
-		titleGenerated: false,
-		ready:          false,
+		input:            input,
+		messages:         displayMessages,
+		sessionID:        sessionID,
+		cfg:              cfg,
+		prov:             prov,
+		dbManager:        dbManager,
+		exec:             exec,
+		ctx:              ctx,
+		cancel:           cancel,
+		waiting:          false,
+		prog:             nil,
+		fullResponse:     strings.Builder{},
+		messageHistory:   history,
+		terminalWidth:    0,
+		terminalHeight:   0,
+		viewport:         viewport.New(0, 0),
+		titleGenerated:   false,
+		ready:            false,
+		maxToolCallDepth: defaultMaxToolCallDepth,
 	}
 }
 
@@ -361,6 +366,17 @@ func (m *ChatModel) renderSidebarContent() string {
 }
 
 func (m *ChatModel) startAIResponse(userInput string) {
+	if strings.TrimSpace(userInput) != "" {
+		m.toolCallDepth = 0
+	} else {
+		m.toolCallDepth++
+	}
+	if m.toolCallDepth > m.maxToolCallDepth {
+		m.prog.Send(fmt.Errorf("tool call recursion depth exceeded (%d)", m.maxToolCallDepth))
+		m.waiting = false
+		return
+	}
+
 	// Save user message synchronously
 	if _, err := m.dbManager.AddMessage(m.sessionID, "user", userInput); err != nil {
 		m.prog.Send(fmt.Errorf("failed to save user message: %w", err))

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -1,0 +1,199 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mnemolet/liberida/internal/config"
+	"github.com/mnemolet/liberida/internal/db"
+	"github.com/mnemolet/liberida/internal/executor"
+	"github.com/mnemolet/liberida/internal/provider"
+)
+
+func TestChatModel_RecursionDepthGuard(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	dbManager, err := db.NewManager(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := dbManager.CreateSession("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execDir := t.TempDir()
+	exec, err := executor.NewLocal(execDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	providerCalls := 0
+
+	mockProv := provider.NewMockProvider()
+	mockProv.WithStreamFunc(func(ctx context.Context, req provider.Request) (<-chan string, <-chan provider.Usage, <-chan []provider.ToolCall, error) {
+		mu.Lock()
+		providerCalls++
+		callNum := providerCalls
+		mu.Unlock()
+
+		chunkChan := make(chan string)
+		usageChan := make(chan provider.Usage, 1)
+		toolChan := make(chan []provider.ToolCall, 1)
+
+		go func() {
+			defer close(chunkChan)
+			defer close(usageChan)
+			defer close(toolChan)
+
+			usageChan <- provider.Usage{}
+
+			toolChan <- []provider.ToolCall{{
+				ID:   fmt.Sprintf("call-%d", callNum),
+				Type: "function",
+				Function: struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				}{
+					Name:      "write_file",
+					Arguments: `{"path":"test.txt","content":"test"}`,
+				},
+			}}
+		}()
+
+		return chunkChan, usageChan, toolChan, nil
+	})
+
+	maxDepth := 5
+	cfg := config.DefaultConfig(config.OSHomeDirProvider{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := NewChatModel(
+		cfg, mockProv, dbManager, exec, session.ID,
+		"system prompt", nil, ctx, cancel,
+	)
+	model.maxToolCallDepth = maxDepth
+
+	prog := tea.NewProgram(model, tea.WithInput(nil), tea.WithOutput(nil))
+	model.SetProgram(prog)
+
+	go func() {
+		prog.Run()
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	model.startAIResponse("hello")
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	calls := providerCalls
+	mu.Unlock()
+
+	if calls == 0 {
+		t.Fatal("provider was never called")
+	}
+	// The provider is called once per recursion level, plus the initial user message.
+	// With maxToolCallDepth=5, we expect at most 6 calls (1 user + up to 5 tool iterations)
+	// before the guard stops recursion.
+	if calls > maxDepth+2 {
+		t.Errorf("provider called %d times, expected at most %d", calls, maxDepth+2)
+	}
+
+	if model.waiting {
+		t.Error("expected model to not be waiting after recursion limit")
+	}
+}
+
+func TestChatModel_RecursionDepthResetOnNewMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	dbManager, err := db.NewManager(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := dbManager.CreateSession("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execDir := t.TempDir()
+	exec, err := executor.NewLocal(execDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	providerCalls := 0
+
+	mockProv := provider.NewMockProvider()
+	mockProv.WithStreamFunc(func(ctx context.Context, req provider.Request) (<-chan string, <-chan provider.Usage, <-chan []provider.ToolCall, error) {
+		mu.Lock()
+		providerCalls++
+		callNum := providerCalls
+		mu.Unlock()
+
+		chunkChan := make(chan string)
+		usageChan := make(chan provider.Usage, 1)
+		toolChan := make(chan []provider.ToolCall, 1)
+
+		go func() {
+			defer close(chunkChan)
+			defer close(usageChan)
+			defer close(toolChan)
+
+			usageChan <- provider.Usage{}
+
+			// Return tools on the first call only; second call (after reset) returns none
+			if callNum == 1 {
+				toolChan <- []provider.ToolCall{{
+					ID:   "call-1",
+					Type: "function",
+					Function: struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					}{
+						Name:      "write_file",
+						Arguments: `{"path":"test.txt","content":"test"}`,
+					},
+				}}
+			} else {
+				toolChan <- nil
+			}
+		}()
+
+		return chunkChan, usageChan, toolChan, nil
+	})
+
+	cfg := config.DefaultConfig(config.OSHomeDirProvider{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := NewChatModel(
+		cfg, mockProv, dbManager, exec, session.ID,
+		"system prompt", nil, ctx, cancel,
+	)
+	model.maxToolCallDepth = 25
+
+	prog := tea.NewProgram(model, tea.WithInput(nil), tea.WithOutput(nil))
+	model.SetProgram(prog)
+
+	go func() {
+		prog.Run()
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	model.startAIResponse("first message")
+	time.Sleep(50 * time.Millisecond)
+
+	if model.toolCallDepth > 1 {
+		t.Errorf("expected depth <= 1 after first turn, got %d", model.toolCallDepth)
+	}
+}


### PR DESCRIPTION
… races

Implements thread-safe file path and system command validation policy rules by guarding fields with a sync.RWMutex. Updates file policy resolution to run against canonical absolute paths post-resolution to neutralize path traversal and symlink bypass vulnerabilities.

Fixes an issue where directory-bound glob patterns (e.g., `.ssh/*`) could be bypassed at deeper nesting levels by shifting from a simple basename match to an iterative path suffix validation sequence.

Additional changes:
- Unexports global blocklist defaults to prevent external package mutation.
- Trims user input whitespace in the TUI to accurately track recursive tool depths.
- Covers traversal, symlink, and deep nested pattern escapes with regression tests.